### PR TITLE
[cb-signal] Changes in preparation for -03

### DIFF
--- a/gss-cb-signalling.xml
+++ b/gss-cb-signalling.xml
@@ -341,24 +341,24 @@ implementations as deployed.</t>
           <t>
 Whenever the initiator application has a) provided channel bindings to
 GSS_Init_sec_context(), and b) not indicated support for the
-ret_channel_bound_flag flag, then the mechanism MUST NOT fail to
+ret_channel_bound_flag flag, then the mechanism SHOULD NOT fail to
 establish a security context just because the acceptor failed to provide
-channel bindings data unless the channel bindings are used for key
-derivation. This requirement is for interoperability purposes, and
-reflects actual implementations that have been deployed.</t>
+channel bindings data.  This strong sugestion is for interoperability
+purposes, and reflects actual implementations that have been
+deployed.</t>
           <t>
 Whenever the application has a) provided channel bindings to
 GSS_Init_sec_context() or GSS_Accept_sec_context(), and b) indicated
-support for the ret_channel_bound_flag flag, then the mechanism MUST NOT
-fail to establish a security context just because the peer did not
-provide channel bindings data unless the channel bindings are used for
-key derivation. The mechanism MUST output the ret_channel_bound_flag if
-both peers provided the same input_channel_bindings to
-GSS_Init_sec_context() and GSS_Accept_sec_context. The mechanism MUST
-NOT output the ret_channel_bound_flag if either (or both) peer did not
-provide input_channel_bindings to GSS_Init/Accept_sec_context(). This
-requirement restores the original base GSS-API specified behavior, with
-the addition of the ret_channel_bound_flag flag.</t>
+support for the ret_channel_bound_flag flag, then the mechanism SHOULD
+NOT fail to establish a security context just because the peer did not
+provide channel bindings data.  The mechanism MUST output the
+ret_channel_bound_flag if both peers provided the same
+input_channel_bindings to GSS_Init_sec_context() and
+GSS_Accept_sec_context(). The mechanism MUST NOT output the
+ret_channel_bound_flag if either (or both) peer did not provide
+input_channel_bindings to GSS_Init/Accept_sec_context(). This requirement
+restores the original base GSS-API specified behavior, with the addition
+of the ret_channel_bound_flag flag.</t>
         </list>
       </t>
     </section>

--- a/gss-cb-signalling.xml
+++ b/gss-cb-signalling.xml
@@ -14,7 +14,6 @@
 <!ENTITY rfc5056 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5056.xml">
 <!ENTITY rfc5587 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5587.xml">
 <!ENTITY rfc4121 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4121.xml">
-<!ENTITY rfc4178 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4178.xml">
 <!ENTITY rfc5653 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5653.xml">
 ]>
 <rfc docName="draft-ietf-kitten-channel-bound-flag-03" ipr="trust200902" category="std" updates="2743, 2744">
@@ -284,12 +283,10 @@ OID assignments TBD.</t>
         <t>
 We add a new request flag for GSS_Init_sec_context(),
 req_cb_confirmation_flag, to be used by initiators that insist on
-acceptors providing channel bindings. This flag is only of use to
-mechanism-negotiation pseudo-mechanisms (e.g., SPNEGO <xref
-  target="RFC4178"/>): if set, the pseudo-mechanism MUST NOT negotiate
-any mechanism which lacks the GSS_C_MA_CBINDINGS attribute and SHOULD
-prefer to negotiate mechanisms which have the GSS_C_MA_CBINDING_CONFIRM
-attribute.</t>
+acceptors providing channel bindings.  If set, the mechanism MUST prefer
+establishment of contexts which provide channel binding confirmation.  It
+SHOULD NOT fail to negotiate just because it cannot provide the
+GSS_C_MA_CBINDING_CONFIRM attribute.</t>
         <section title="C-Bindings" anchor="d1e620">
           <t>
 Because GSS_C_CHANNEL_BOUND_FLAG is a return flag only, and this flag is
@@ -390,8 +387,7 @@ Mechanism gsscma Codes” registry established by RFC5587 <xref
 &rfc5056;
 &rfc5587;
 </references>
-    <references title="Informative References">&rfc4178;
-&rfc4121;
+    <references title="Informative References">&rfc4121;
 &rfc5653;
 </references>
   </back>


### PR DESCRIPTION
* First commit reflects the state of the draft as of -02.
* Second commit removes language that was supposed to have been removed already.
* Third commit removes a TODO on Nico which I cannot satisfy.  (Nico, if you want to / can, please feel free to add the SSPI information back in.)
* Fourth commit removes `GSS_C_MA_CBINDING_MAY_CONFIRM`, as per IRC discussion, prompted by Greg's review.
* Fifth commit addresses a concern raised in Greg's review [here](https://github.com/nicowilliams/kitten/pull/1#discussion_r138522748) about mechanisms using channel bindings for key derivation.  There are two other ways I see to address this: (1) decide we don't care about such mechanisms and leave the language alone, or (2) relax the MUST in the third requirement (and make corresponding changes to the fourth).
* Sixth commit gets us ready for -03 submission, unless there's anything else missing.